### PR TITLE
Updated documentation to meet godoc/golint standards

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -34,7 +34,9 @@ var (
 	ErrClosed = errors.New("pool is closed")
 )
 
+// Closeable interface describes a closable implementation.  The underlying procedure of the Close() function is determined by its implementation  
 type Closeable interface {
+        // Close closes the object
 	Close() error
 }
 
@@ -63,7 +65,7 @@ type PoolConn struct {
 	unusable bool
 }
 
-// Close() puts the given connects back to the pool instead of closing it.
+// Close puts the given connects back to the pool instead of closing it.
 func (p *PoolConn) Close() error {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
@@ -77,14 +79,14 @@ func (p *PoolConn) Close() error {
 	return p.c.put(p.Closeable)
 }
 
-// MarkUnusable() marks the connection not usable any more, to let the pool close it instead of returning it to pool.
+// MarkUnusable marks the connection not usable any more, to let the pool close it instead of returning it to pool.
 func (p *PoolConn) MarkUnusable() {
 	p.mu.Lock()
 	p.unusable = true
 	p.mu.Unlock()
 }
 
-// newConn wraps a standard net.Conn to a poolConn net.Conn.
+// wrapConn wraps a standard net.Conn to a poolConn net.Conn.
 func (c *channelPool) wrapConn(conn Closeable) Closeable {
 	p := &PoolConn{c: c}
 	p.Closeable = conn
@@ -195,6 +197,7 @@ func (c *channelPool) put(conn Closeable) error {
 	}
 }
 
+// Close shuts down all of the Closeable objects in the Pool
 func (c *channelPool) Close() {
 	c.mu.Lock()
 	conns := c.conns
@@ -212,4 +215,5 @@ func (c *channelPool) Close() {
 	}
 }
 
+// Len returns the number of Closeable objects in the Pool
 func (c *channelPool) Len() int { return len(c.getConns()) }

--- a/runner.go
+++ b/runner.go
@@ -15,21 +15,23 @@ import (
 )
 
 var (
+        // SIGTERM is an alias for syscall.SIGTERM
 	SIGTERM os.Signal = syscall.SIGTERM
+        // SIGTSTP is an alias for syscall.SIGSTP
 	SIGTSTP os.Signal = syscall.SIGTSTP
+        // SIGINT is and alias for syscall.SIGINT
 	SIGINT  os.Signal = os.Interrupt
 )
 
-/*
- * Register a handler for the given jobtype.  It is expected that all jobtypes
- * are registered upon process startup.
- *
- * faktory_worker.Register("ImportantJob", ImportantFunc)
- */
+// Register registers a handler for the given jobtype.  It is expected that all jobtypes
+// are registered upon process startup.
+//
+// faktory_worker.Register("ImportantJob", ImportantFunc)
 func (mgr *Manager) Register(name string, fn Perform) {
 	mgr.jobHandlers[name] = fn
 }
 
+// Manager coordinates the processes for the worker.  It is responsible for starting and stopping goroutines to perform work at the desired concurrency level
 type Manager struct {
 	Concurrency int
 	Queues      []string
@@ -42,11 +44,12 @@ type Manager struct {
 	jobHandlers    map[string]Perform
 }
 
+// Quiet is not yet implemented
 func (mgr *Manager) Quiet() {
 	// TODO
 }
 
-// Signals that the various components should shutdown.
+// Terminate signals that the various components should shutdown.
 // Blocks on the shutdownWaiter until all components have finished.
 func (mgr *Manager) Terminate() {
 	util.Info("Shutting down...")
@@ -57,6 +60,7 @@ func (mgr *Manager) Terminate() {
 	os.Exit(0)
 }
 
+// NewManager returns a new manager with default values.
 func NewManager() *Manager {
 	return &Manager{
 		Concurrency: 20,
@@ -68,10 +72,8 @@ func NewManager() *Manager {
 	}
 }
 
-/*
- * Start processing jobs.
- * This method does not return.
- */
+// Run starts processing jobs.
+// This method does not return.
 func (mgr *Manager) Run() {
 	if mgr.Pool == nil {
 		pool, err := NewChannelPool(0, mgr.Concurrency, func() (Closeable, error) { return faktory.Open() })
@@ -199,12 +201,14 @@ func process(mgr *Manager, idx int) {
 	}
 }
 
+// DefaultContext embeds Go's standard context and associates it with a job ID.
 type DefaultContext struct {
 	context.Context
 
 	JID string
 }
 
+// Jid returns the job ID for the default context
 func (c *DefaultContext) Jid() string {
 	return c.JID
 }

--- a/types.go
+++ b/types.go
@@ -5,25 +5,24 @@ import (
 )
 
 const (
+        // Version is the current version
 	Version = "0.5.0"
 )
 
-/*
- * The job context provides Go's standard Context pattern
- * along with a select few additions for job processing.
- *
- * We're pretty strict about what's exposed in the Context
- * because execution should be orthogonal to
- * most of the Job payload contents.
- */
+
+// Context provides Go's standard Context pattern
+// along with a select few additions for job processing.
+//
+// We're pretty strict about what's exposed in the Context
+// because execution should be orthogonal to
+// most of the Job payload contents.
 type Context interface {
 	context.Context
 
 	Jid() string
 }
 
-/*
- * The Perform function actually executes the job.
- * It must be thread-safe.
- */
+
+// Perform actually executes the job.
+// It must be thread-safe.
 type Perform func(ctx Context, args ...interface{}) error


### PR DESCRIPTION
- Converted block-style comment to the Godoc preffered line comments
- Documented all exported members as per Golint
- Each comment starts with the member name as per Golint