### PR TITLE
Allow replacing the logger

### DIFF
--- a/log.go
+++ b/log.go
@@ -1,0 +1,59 @@
+package faktory_worker
+
+import (
+	"log"
+	"os"
+)
+
+type Logger interface {
+	Debug(v ...interface{})
+	Debugf(format string, args ...interface{})
+	Info(v ...interface{})
+	Infof(format string, args ...interface{})
+	Warn(v ...interface{})
+	Warnf(format string, args ...interface{})
+	Error(v ...interface{})
+	Errorf(format string, args ...interface{})
+	Fatal(v ...interface{})
+	Fatalf(format string, args ...interface{})
+}
+
+type StdLogger struct {
+	*log.Logger
+}
+
+func NewStdLogger() Logger {
+	return &StdLogger{log.New(os.Stdout, "Faktory ", log.LstdFlags)}
+}
+
+func (l *StdLogger) Debug(v ...interface{}) {
+	l.Println(v...)
+}
+
+func (l *StdLogger) Debugf(format string, v ...interface{}) {
+	l.Printf(format + "\n", v...)
+}
+
+func (l *StdLogger) Error(v ...interface{}) {
+	l.Println(v...)
+}
+
+func (l *StdLogger) Errorf(format string, v ...interface{}) {
+	l.Printf(format + "\n", v...)
+}
+
+func (l *StdLogger) Info(v ...interface{}) {
+	l.Println(v...)
+}
+
+func (l *StdLogger) Infof(format string, v ...interface{}) {
+	l.Printf(format + "\n", v...)
+}
+
+func (l *StdLogger) Warn(v ...interface{}) {
+	l.Println(v...)
+}
+
+func (l *StdLogger) Warnf(format string, v ...interface{}) {
+	l.Printf(format + "\n", v...)
+}


### PR DESCRIPTION
This will allow anyone to override the logger or disable the logger completely. Example usages:

```go
// Disable logging
mgr.Logger = &worker.StdLogger{log.New(ioutil.Discard, "", 0)}

// Use Logrus logging
mgr.Logger = logrus.WithField("system", "faktory")
```