### PR TITLE
Add middleware support

### DIFF
--- a/test/main.go
+++ b/test/main.go
@@ -19,10 +19,10 @@ func someFunc(ctx worker.Context, args ...interface{}) error {
 
 func main() {
 	mgr := worker.NewManager()
-	mgr.Use(func(perform worker.Perform) worker.Perform {
-		return func(ctx worker.Context, args ...interface{}) error {
-			log.Printf("Starting work on job %s of type %s\n", ctx.Jid(), ctx.JobType())
-			err := perform(ctx, args...)
+	mgr.Use(func(perform worker.Handler) worker.Handler {
+		return func(ctx worker.Context, job *faktory.Job) error {
+			log.Printf("Starting work on job %s of type %s with custom %v\n", ctx.Jid(), ctx.JobType(), job.Custom)
+			err := perform(ctx, job)
 			log.Printf("Finished work on job %s with error %v\n", ctx.Jid(), err)
 			return err
 		}
@@ -64,7 +64,11 @@ func produce() {
 		panic(err)
 	}
 
-	err = cl.Push(faktory.NewJob("SomeJob", 1, 2, "hello"))
+	job := faktory.NewJob("SomeJob", 1, 2, "hello")
+	job.Custom = map[string]interface{}{
+		"hello": "world",
+	}
+	err = cl.Push(job)
 	if err != nil {
 		panic(err)
 	}

--- a/test/main.go
+++ b/test/main.go
@@ -19,6 +19,14 @@ func someFunc(ctx worker.Context, args ...interface{}) error {
 
 func main() {
 	mgr := worker.NewManager()
+	mgr.Use(func(perform worker.Perform) worker.Perform {
+		return func(ctx worker.Context, args ...interface{}) error {
+			log.Printf("Starting work on job %s of type %s\n", ctx.Jid(), ctx.JobType())
+			err := perform(ctx, args...)
+			log.Printf("Finished work on job %s with error %v\n", ctx.Jid(), err)
+			return err
+		}
+	})
 
 	// register job types and the function to execute them
 	mgr.Register("SomeJob", someFunc)

--- a/types.go
+++ b/types.go
@@ -2,6 +2,8 @@ package faktory_worker
 
 import (
 	"context"
+
+	faktory "github.com/contribsys/faktory/client"
 )
 
 const (
@@ -26,5 +28,7 @@ type Context interface {
 // It must be thread-safe.
 type Perform func(ctx Context, args ...interface{}) error
 
+type Handler func(ctx Context, job *faktory.Job) error
+
 // MiddlewareFunc defines a function to process middleware.
-type MiddlewareFunc func(Perform) Perform
+type MiddlewareFunc func(Handler) Handler

--- a/types.go
+++ b/types.go
@@ -19,8 +19,12 @@ type Context interface {
 	context.Context
 
 	Jid() string
+	JobType() string
 }
 
 // Perform actually executes the job.
 // It must be thread-safe.
 type Perform func(ctx Context, args ...interface{}) error
+
+// MiddlewareFunc defines a function to process middleware.
+type MiddlewareFunc func(Perform) Perform


### PR DESCRIPTION
I added chained middleware support on manager and job type level, so middleware can also be added on an individual job. I also added `context.JobType()` to allow retrieving the job type because it can be useful in middleware.

Example usage:

```go
mgr.Use(func(perform worker.Perform) worker.Perform {
	return func(ctx worker.Context, args ...interface{}) error {
		log.Printf("Starting work on job %s of type %s\n", ctx.Jid(), ctx.JobType())
		err := perform(ctx, args...)
		log.Printf("Finished work on job %s with error %v\n", ctx.Jid(), err)
		return err
	}
})
```

When applied in the `test` package, it will transform this output:

```
2018/02/02 12:42:41 Working on job p5d9qprOQK6k_2dU
2018/02/02 12:42:41 Context &{context.Background p5d9qprOQK6k_2dU SomeJob}
2018/02/02 12:42:41 Args [1 2 hello]
```

Into this output:

```
2018/02/02 12:42:41 Starting work on job p5d9qprOQK6k_2dU of type SomeJob
2018/02/02 12:42:41 Working on job p5d9qprOQK6k_2dU
2018/02/02 12:42:41 Context &{context.Background p5d9qprOQK6k_2dU SomeJob}
2018/02/02 12:42:41 Args [1 2 hello]
2018/02/02 12:42:41 Finished work on job j-XwEx2tFS93I6Op with error <nil>
```

Example usage with Logrus and only logging errors:

```go
entry := logrus.WithField("system", "faktory")

mgr.Use(func(perform worker.Perform) worker.Perform {
	return func(ctx worker.Context, args ...interface{}) error {
		err := perform(ctx, args...)
		entry := entry.WithFields(logrus.Fields{
			"jid":     ctx.Jid(),
			"jobtype": ctx.JobType(),
		})
		if err != nil {
			entry.WithError(err).Errorf("Failed to execute job")
		}
		return err
	}
})
```