### PR TITLE
Added marking connections unusable if error returned

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -277,6 +277,9 @@ func (mgr *Manager) with(fn func(fky *faktory.Client) error) error {
 		return fmt.Errorf("Connection is not a Faktory client instance: %+v", conn)
 	}
 	err = fn(f)
+	if err != nil {
+		pc.MarkUnusable()
+	}
 	conn.Close()
 	return err
 }


### PR DESCRIPTION
Fixed `write tcp [::1]:63385->[::1]:7419: write: broken pipe` when Factory server was restarted.