### PR TITLE
Fix processes not being shut down on shutdown

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -218,6 +218,13 @@ func process(mgr *Manager, idx int) {
 			return
 		}
 
+		// check for shutdown
+		select {
+		case <-mgr.done:
+			return
+		default:
+		}
+
 		// fetch job
 		var job *faktory.Job
 		var err error
@@ -262,14 +269,6 @@ func process(mgr *Manager, idx int) {
 			// if there are no jobs, Faktory will block us on
 			// the first queue, so no need to poll or sleep
 		}
-
-		// check for shutdown
-		select {
-		case <-mgr.done:
-			return
-		default:
-		}
-
 	}
 }
 


### PR DESCRIPTION
When an error occurs while connecting to the server, for example the server is not up, the worker is unable to shut down. The shutdown check for the worker goroutines is not executed when an error occurs connecting to the server.

This moves the shutdown check up to always check whether the worker should shut down.