### PR TITLE
support building on bsd and other unices

### DIFF
--- a/runner_unix.go
+++ b/runner_unix.go
@@ -1,4 +1,4 @@
-// +build linux bsd darwin
+// +build linux freebsd netbsd openbsd darwin
 
 package faktory_worker
 

--- a/runner_unix.go
+++ b/runner_unix.go
@@ -1,4 +1,4 @@
-// +build linux freebsd netbsd openbsd darwin
+// +build linux freebsd netbsd openbsd dragonfly solaris illumos aix darwin
 
 package faktory_worker
 


### PR DESCRIPTION
Currently, building on OpenBSD (and presumably freebsd, netbsd, dragonflybsd, etc) results in runner_unix.go not actually being built and `hookSignals` and `signalMap` being undefined. So anything relying on faktory_worker_go fails to build.

This patch is super simple, we're just changing the build tag from the (invalid?) "bsd" to bsd OSes explicitly defined in `go tool dist list`. After this change, faktory_worker_go builds and works as expected on an OpenBSD now.

Also: I went ahead and added illumos and solaris to the build tags for this file, since they implement the same signals and _should_(?) work as well.