### PR TITLE
Fixes bid key on jobHelper.Bid()

### DIFF
--- a/context.go
+++ b/context.go
@@ -77,7 +77,7 @@ func (h *jobHelper) Jid() string {
 	return h.job.Jid
 }
 func (h *jobHelper) Bid() string {
-	if b, ok := h.job.GetCustom("bid"); ok {
+	if b, ok := h.job.GetCustom("_bid"); ok {
 		return b.(string)
 	}
 	return ""

--- a/context_test.go
+++ b/context_test.go
@@ -49,7 +49,7 @@ func TestBatchContext(t *testing.T) {
 
 	job := faktory.NewJob("something", 1, 2)
 	job.SetCustom("track", 1)
-	job.SetCustom("bid", "nosuchbatch")
+	job.SetCustom("_bid", "nosuchbatch")
 
 	ctx := jobContext(pool, job)
 	help := HelperFor(ctx)


### PR DESCRIPTION
Hey!

I noticed that calling the following inside a Batch Job was returning an empty string `""` 

```
helper := faktory_worker.HelperFor(ctx)
heper.Bid() // returned ""
```

By debugging the code I found that the key to get `bid` from the `job.custom` was actually `_bid` but the lib is trying to get it from `bid`

### System Information
Faktory Enterprise 1.4.1 
Faktory Worker Go 1.4.1