### PR TITLE
run with context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
+
+# Folder by any jetbrains IDE
+/.idea

--- a/manager.go
+++ b/manager.go
@@ -144,8 +144,9 @@ func (mgr *Manager) setUpWorkerProcess() error {
 	return nil
 }
 
-// RunWithContext starts processing jobs.
-// If the context is present then os signals will be ignored, the context must be canceled for the method to return.
+// RunWithContext starts processing jobs. The method will return if an error is encountered while starting.
+// If the context is present then os signals will be ignored, the context must be canceled for the method to return
+// after running.
 func (mgr *Manager) RunWithContext(ctx context.Context) error {
 	if err := mgr.setUpWorkerProcess(); err != nil {
 		return err
@@ -173,7 +174,7 @@ func (mgr *Manager) RunWithContext(ctx context.Context) error {
 }
 
 // Run starts processing jobs.
-// This method does not return.
+// This method does not return unless an error is encountered while starting.
 func (mgr *Manager) Run() error {
 	return mgr.RunWithContext(nil)
 }

--- a/manager_test.go
+++ b/manager_test.go
@@ -58,7 +58,18 @@ func TestManagerSetup(t *testing.T) {
 	mgr.Logger = logg
 	assert.Equal(t, "", mgr.handleEvent("dump"))
 
+	terminateCalled := false
+	mgr.On(Shutdown, func(m *Manager) error {
+		terminateCalled = true
+		assert.NotNil(t, m)
+		return nil
+	})
 	mgr.Terminate(false)
+	assert.Equal(t, true, terminateCalled)
+	// calling terminate again should be a noop
+	terminateCalled = false
+	mgr.Terminate(false)
+	assert.Equal(t, false, terminateCalled)
 }
 
 func withServer(t *testing.T, lvl string, mgr *Manager, fn func(cl *faktory.Client) error) {


### PR DESCRIPTION
In references to https://github.com/contribsys/faktory/issues/391

added RunWithContext and added mutex to Quiet, Terminate, and setUpWorkerProcess methods
allowing restarting of manager
ignoring jetbrains ide folder
