### PR TITLE
Add support for retrieving batch ID from within batch complete job

### DIFF
--- a/context.go
+++ b/context.go
@@ -80,6 +80,9 @@ func (h *jobHelper) Bid() string {
 	if b, ok := h.job.GetCustom("bid"); ok {
 		return b.(string)
 	}
+	if b, ok := h.job.GetCustom("_bid"); ok { // for batch complete jobs
+		return b.(string)
+	}
 	return ""
 }
 func (h *jobHelper) JobType() string {

--- a/context.go
+++ b/context.go
@@ -45,6 +45,10 @@ type Helper interface {
 	Bid() string
 
 	// Faktory Enterprise:
+	// the BID of the Batch associated with this callback (complete or success) job
+	CallbackBid() string
+
+	// Faktory Enterprise:
 	// open the batch associated with this job so we can add more jobs to it.
 	//
 	//   func myJob(ctx context.Context, args ...interface{}) error {
@@ -80,7 +84,10 @@ func (h *jobHelper) Bid() string {
 	if b, ok := h.job.GetCustom("bid"); ok {
 		return b.(string)
 	}
-	if b, ok := h.job.GetCustom("_bid"); ok { // for batch complete jobs
+	return ""
+}
+func (h *jobHelper) CallbackBid() string {
+	if b, ok := h.job.GetCustom("_bid"); ok {
 		return b.(string)
 	}
 	return ""


### PR DESCRIPTION
Hi,  as a complete job handling the status of a batch, I need access to the batch ID.

I did just test this with our setup. Works fine.

Has been confirmed by the support: >> The BID is actually stored as "_bid" in the callback job's Custom hash. <<

Best Regards, Felix
