### PR TITLE
Replace syscall.Kill with os.FindProcess / Signal for windows compati…

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -47,7 +47,11 @@ func heartbeat(mgr *Manager) {
 					// If our heartbeat expires, we must restart and re-authenticate.
 					// Use a signal so we can unwind and shutdown cleanly.
 					mgr.Logger.Warn("Faktory heartbeat has expired, shutting down...")
-					_ = syscall.Kill(os.Getpid(), syscall.SIGTERM)
+					if process, err := os.FindProcess(os.Getpid()); err != nil {
+						mgr.Logger.Errorf("Could not find worker process %d: %v", os.Getpid(), err)
+					} else {
+						_ = process.Signal(syscall.SIGTERM)
+					}
 				}
 				if err != nil || data == "" {
 					return err


### PR DESCRIPTION
…bility

Currently the package cannot be compiled on Windows due to `syscall.Kill` being undefined on the system.
```
# github.com/contribsys/faktory_worker_go
..\..\..\go\pkg\mod\github.com\contribsys\faktory_worker_go@v1.6.0\runner.go:49:18: undefined: syscall.Kill
```

This change replaces the call with os package [FindProcess](https://pkg.go.dev/os#FindProcess) and [Signal](https://pkg.go.dev/os#Process.Signal) calls to maintain cross-compatibility.