### PR TITLE
Implement hard shutdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
         ports: ['7419:7419']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
         go-version: 1.17
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         go-version: 1.17
 
     - name: Install linter
-      run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.44.0
+      run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.56.1
 
     - name: Test
       run: make lint test

--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,16 @@
 # faktory\_worker\_go
 
+## 1.7.0
+
+- Implement hard shutdown timeout of 25 seconds. [#76]
+  Your job funcs should implement `context` package semantics.
+  If you use `Manager.Run()`, FWG will now gracefully shutdown.
+  After a default delay of 25 seconds, FWG will cancel the root Context which should quickly cancel any lingering jobs running under that Manager.
+  If your jobs run long and do not respond to context cancellation, you risk orphaning any jobs in-progress.
+  They will linger on the Busy tab until the job's `reserve_for` timeout.
+
+  Please also note that `RunWithContext` added in `1.6.0` does not implement the shutdown delay but the README example contains the code to implement it.
+
 ## 1.6.0
 
 - Upgrade to Go 1.17 and Faktory 1.6.0.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test:
-	go test -v ./...
+	go test ./...
 
 work:
 	go run test/main.go

--- a/context.go
+++ b/context.go
@@ -28,14 +28,13 @@ var (
 // because execution should be orthogonal to
 // most of the Job payload contents.
 //
-//   func myJob(ctx context.Context, args ...interface{}) error {
-//     helper := worker.HelperFor(ctx)
-//     jid := helper.Jid()
+//	  func myJob(ctx context.Context, args ...interface{}) error {
+//	    helper := worker.HelperFor(ctx)
+//	    jid := helper.Jid()
 //
-//     helper.With(func(cl *faktory.Client) error {
-//       cl.Push("anotherJob", 4, "arg")
-//		 })
-//
+//	    helper.With(func(cl *faktory.Client) error {
+//	      cl.Push("anotherJob", 4, "arg")
+//			 })
 type Helper interface {
 	Jid() string
 	JobType() string
@@ -127,8 +126,7 @@ func HelperFor(ctx context.Context) Helper {
 	return nil
 }
 
-func jobContext(pool *faktory.Pool, job *faktory.Job) context.Context {
-	ctx := context.Background()
+func jobContext(ctx context.Context, pool *faktory.Pool, job *faktory.Job) context.Context {
 	ctx = context.WithValue(ctx, poolKey, pool)
 	ctx = context.WithValue(ctx, jobKey, job)
 	return ctx

--- a/context_test.go
+++ b/context_test.go
@@ -1,9 +1,11 @@
 package faktory_worker
 
 import (
+	"context"
 	"errors"
 	"regexp"
 	"testing"
+	"time"
 
 	faktory "github.com/contribsys/faktory/client"
 	"github.com/stretchr/testify/assert"
@@ -21,15 +23,16 @@ func TestSimpleContext(t *testing.T) {
 	//cl, err := faktory.Open()
 	//assert.NoError(t, err)
 	//cl.Push(job)
-
-	ctx := jobContext(pool, job)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	ctx = jobContext(ctx, pool, job)
 	help := HelperFor(ctx)
 	assert.Equal(t, help.Jid(), job.Jid)
 	assert.Empty(t, help.Bid())
 	assert.Equal(t, "something", help.JobType())
 
 	_, ok := ctx.Deadline()
-	assert.False(t, ok)
+	assert.True(t, ok)
 
 	//assert.NoError(t, ctx.TrackProgress(45, "Working....", nil))
 
@@ -51,7 +54,9 @@ func TestBatchContext(t *testing.T) {
 	job.SetCustom("track", 1)
 	job.SetCustom("bid", "nosuchbatch")
 
-	ctx := jobContext(pool, job)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	ctx = jobContext(ctx, pool, job)
 	help := HelperFor(ctx)
 	assert.Equal(t, help.Jid(), job.Jid)
 	assert.Equal(t, "nosuchbatch", help.Bid())

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/contribsys/faktory_worker_go
 
-go 1.20
+go 1.21
 
 toolchain go1.21.4
 

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/contribsys/faktory_worker_go
 
 go 1.21
 
-toolchain go1.21.4
-
 require (
 	github.com/contribsys/faktory v1.8.0
 	github.com/stretchr/testify v1.8.4

--- a/middleware.go
+++ b/middleware.go
@@ -14,7 +14,7 @@ func (mgr *Manager) Use(middleware ...MiddlewareFunc) {
 	mgr.middleware = append(mgr.middleware, middleware...)
 }
 
-func dispatch(chain []MiddlewareFunc, ctx context.Context, job *faktory.Job, perform Handler) error {
+func dispatch(ctx context.Context, chain []MiddlewareFunc, job *faktory.Job, perform Handler) error {
 	if len(chain) == 0 {
 		return perform(ctx, job)
 	}
@@ -22,6 +22,6 @@ func dispatch(chain []MiddlewareFunc, ctx context.Context, job *faktory.Job, per
 	link := chain[0]
 	rest := chain[1:]
 	return link(ctx, job, func(ctx context.Context) error {
-		return dispatch(rest, ctx, job, perform)
+		return dispatch(ctx, rest, job, perform)
 	})
 }

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -3,6 +3,7 @@ package faktory_worker
 import (
 	"context"
 	"testing"
+	"time"
 
 	faktory "github.com/contribsys/faktory/client"
 	"github.com/stretchr/testify/assert"
@@ -34,12 +35,14 @@ func TestMiddleware(t *testing.T) {
 		return nil
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
 	job := faktory.NewJob("blah", 1, 2)
-	ctx := jobContext(mgr.Pool, job)
+	ctx = jobContext(ctx, mgr.Pool, job)
 	assert.Nil(t, ctx.Value(EXAMPLE))
 	assert.EqualValues(t, 0, counter)
 
-	err = dispatch(mgr.middleware, ctx, job, blahFunc)
+	err = dispatch(ctx, mgr.middleware, job, blahFunc)
 
 	assert.NoError(t, err)
 	assert.EqualValues(t, 1, counter)

--- a/runner.go
+++ b/runner.go
@@ -1,6 +1,7 @@
 package faktory_worker
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -77,7 +78,7 @@ func heartbeat(mgr *Manager) {
 	}
 }
 
-func process(mgr *Manager, idx int) {
+func process(ctx context.Context, mgr *Manager, idx int) {
 	mgr.shutdownWaiter.Add(1)
 	defer mgr.shutdownWaiter.Done()
 
@@ -97,7 +98,7 @@ func process(mgr *Manager, idx int) {
 		default:
 		}
 
-		err := processOne(mgr)
+		err := processOne(ctx, mgr)
 		if err != nil {
 			mgr.Logger.Debug(err)
 			if _, ok := err.(*NoHandlerError); !ok {
@@ -123,7 +124,7 @@ func process(mgr *Manager, idx int) {
 	}
 }
 
-func processOne(mgr *Manager) error {
+func processOne(ctx context.Context, mgr *Manager) error {
 	var job *faktory.Job
 
 	// explicit scopes to limit variable visibility
@@ -155,7 +156,7 @@ func processOne(mgr *Manager) error {
 		return je
 	}
 
-	joberr := mgr.dispatch(job)
+	joberr := mgr.dispatch(ctx, job)
 	if joberr != nil {
 		// job errors are normal and expected, we don't return early from them
 		mgr.Logger.Errorf("Error running %s job %s: %v", job.Type, job.Jid, joberr)

--- a/runner_test.go
+++ b/runner_test.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"os"
 	"testing"
+	"time"
 
 	faktory "github.com/contribsys/faktory/client"
 	"github.com/stretchr/testify/assert"
@@ -75,7 +76,10 @@ func TestLiveServer(t *testing.T) {
 		err := cl.Push(j)
 		assert.NoError(t, err)
 
-		err = processOne(mgr)
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+
+		err = processOne(ctx, mgr)
 		assert.Error(t, err)
 		_, ok := err.(*NoHandlerError)
 		assert.True(t, ok)
@@ -86,7 +90,7 @@ func TestLiveServer(t *testing.T) {
 		err = cl.Push(j)
 		assert.NoError(t, err)
 
-		err = processOne(mgr)
+		err = processOne(ctx, mgr)
 		assert.NoError(t, err)
 		return nil
 	})

--- a/testing.go
+++ b/testing.go
@@ -1,6 +1,7 @@
 package faktory_worker
 
 import (
+	"context"
 	"encoding/json"
 
 	faktory "github.com/contribsys/faktory/client"
@@ -8,6 +9,7 @@ import (
 
 type PerformExecutor interface {
 	Execute(*faktory.Job, Perform) error
+	ExecuteContext(context.Context, *faktory.Job, Perform) error
 }
 
 type testExecutor struct {
@@ -19,6 +21,11 @@ func NewTestExecutor(p *faktory.Pool) PerformExecutor {
 }
 
 func (tp *testExecutor) Execute(specjob *faktory.Job, p Perform) error {
+	ctx := context.Background()
+	return tp.ExecuteContext(ctx, specjob, p)
+}
+
+func (tp *testExecutor) ExecuteContext(ctx context.Context, specjob *faktory.Job, p Perform) error {
 	// perform a JSON round trip to ensure Perform gets the arguments
 	// exactly how a round trip to Faktory would look.
 	data, err := json.Marshal(specjob)
@@ -31,6 +38,6 @@ func (tp *testExecutor) Execute(specjob *faktory.Job, p Perform) error {
 		return err
 	}
 
-	c := jobContext(tp.Pool, &job)
+	c := jobContext(ctx, tp.Pool, &job)
 	return p(c, job.Args...)
 }

--- a/types.go
+++ b/types.go
@@ -3,7 +3,7 @@ package faktory_worker
 import "context"
 
 const (
-	Version = "1.6.0"
+	Version = "1.7.0"
 )
 
 // Perform actually executes the job.


### PR DESCRIPTION
Implement hard shutdown timeout of 25 seconds.

Your job funcs should implement `context` package semantics. If you use `Manager.Run`, FWG will now gracefully shutdown. After a default delay of 25 seconds, FWG will cancel the root Context which should quickly cancel any lingering jobs running under that Manager. If your jobs run long and do not respond to context cancellation, you risk orphaning any jobs in-progress. They will linger on the Busy tab until the job's `reserve_for` timeout.

Please also note that `Manager.RunWithContext` added in `1.6.0` does not implement the shutdown delay but the README example contains the code to implement it.

Fixes #76 