### PR TITLE
InlineDispatch: Add JSON serialization to match real server behaviour

### DIFF
--- a/manager_test.go
+++ b/manager_test.go
@@ -110,57 +110,21 @@ func TestInlineDispatchArgsSerialization(t *testing.T) {
 		return nil
 	})
 
-	// Test with various argument types that change during JSON serialization
-	job := faktory.NewJob("test_job",
-		int(42),                                // becomes float64
-		int64(123),                             // becomes float64
-		float32(3.14),                          // becomes float64
-		"hello",                                // remains string
-		true,                                   // remains bool
-		map[string]interface{}{"key": "value"}, // remains map
-	)
-
-	err := mgr.InlineDispatch(job)
-	assert.NoError(t, err)
-
-	// Verify that numeric types were converted to float64 (JSON default)
-	assert.Equal(t, float64(42), receivedArgs[0])
-	assert.Equal(t, float64(123), receivedArgs[1])
-	assert.Equal(t, float64(3.14), receivedArgs[2])
-	assert.Equal(t, "hello", receivedArgs[3])
-	assert.Equal(t, true, receivedArgs[4])
-	assert.Equal(t, map[string]interface{}{"key": "value"}, receivedArgs[5])
-}
-
-func TestInlineDispatchNonRegisteredJob(t *testing.T) {
-	mgr := NewManager()
-
-	job := faktory.NewJob("non_existent_job", "arg1", "arg2")
-
-	err := mgr.InlineDispatch(job)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "job not registered")
-}
-
-func TestSerializeArgs(t *testing.T) {
-	// Test the helper function directly
-	originalArgs := []interface{}{
-		int(42),
-		int64(123),
-		float32(3.14),
-		"hello",
-		true,
-		map[string]interface{}{"key": "value"},
+	// Create a temporary struct that will become a map after JSON serialization
+	type tempStruct struct {
+		Name string `json:"name"`
+		Age  int    `json:"age"`
 	}
 
-	serializedArgs, err := serializeArgs(originalArgs)
+	job := faktory.NewJob("test_job", tempStruct{Name: "John", Age: 30})
+
+	err := mgr.InlineDispatch(job)
 	assert.NoError(t, err)
 
-	// Verify that numeric types were converted to float64
-	assert.Equal(t, float64(42), serializedArgs[0])
-	assert.Equal(t, float64(123), serializedArgs[1])
-	assert.Equal(t, float64(3.14), serializedArgs[2])
-	assert.Equal(t, "hello", serializedArgs[3])
-	assert.Equal(t, true, serializedArgs[4])
-	assert.Equal(t, map[string]interface{}{"key": "value"}, serializedArgs[5])
+	// Verify that the struct was converted to a map during serialization
+	assert.Len(t, receivedArgs, 1)
+	argMap, ok := receivedArgs[0].(map[string]interface{})
+	assert.True(t, ok, "Expected argument to be converted to map[string]interface{}")
+	assert.Equal(t, "John", argMap["name"])
+	assert.Equal(t, float64(30), argMap["age"]) // JSON converts numbers to float64
 }


### PR DESCRIPTION
## Context

The `Manager.InlineDispatch` implementation has a subtle difference in behaviour when compared to the real service: the arguments are not encoded/decoded.

This can lead to some subtle bugs when using it to write unit/integration tests of the worker implementation, as passing a struct as an argument will not match the real behaviour.

## Solution

Add a new method that encodes/decodes the arguemnts, this way `InlineDispatch` will match the real behaviour.


P.S. I used copilot agent for this change mostly as a test, I carefully reviewed the code and it matches what I would have done (also it didn't save me any time at all 😂 ).